### PR TITLE
[Strawman] Use react-dom's test suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "react"]
+	path = react
+	url = https://github.com/prometheansacrifice/react


### PR DESCRIPTION
WIP. I'm looking for feedback, overall viability and other concerns. Basic idea: Map react-dom to react-dom-lite using jest's module mapper. Running `yarn test-rdl` inside react would run only react-dom tests, with react-dom resolving to react-dom-lite.